### PR TITLE
Add the ability to turn off half stars

### DIFF
--- a/addon/components/star-rating.js
+++ b/addon/components/star-rating.js
@@ -16,6 +16,7 @@ const RatingComponent = Component.extend({
   readOnly: false,
   width: 26,
   height: 26,
+  useHalfStars: true,
   svgPath: 'M25.326,10.137c-0.117-0.361-0.431-0.625-0.807-0.68l-7.34-1.066l-3.283-6.651 c-0.337-0.683-1.456-0.683-1.793,0L8.82,8.391L1.48,9.457c-0.376,0.055-0.689,0.318-0.807,0.68c-0.117,0.363-0.02,0.76,0.253,1.025 l5.312,5.178l-1.254,7.31c-0.064,0.375,0.09,0.755,0.397,0.978c0.309,0.225,0.717,0.254,1.054,0.076L13,21.252l6.564,3.451 c0.146,0.077,0.307,0.115,0.466,0.115c0.207,0,0.413-0.064,0.588-0.191c0.308-0.223,0.462-0.603,0.397-0.978l-1.254-7.31 l5.312-5.178C25.346,10.896,25.443,10.5,25.326,10.137z',
   viewBox: '0 0 26 26',
 
@@ -93,17 +94,29 @@ const RatingComponent = Component.extend({
 
   _getTarget(x) {
     const numStars = get(this, 'numStars');
-    return (numStars * (x - this.$().offset().left) / this.$().width() + 0.5);
+    const numStarsFilled = (numStars * (x - this.$().offset().left) / this.$().width() + 0.5);
+    if (get(this, 'useHalfStars')) {
+      return numStarsFilled;
+    }
+    return Math.ceil(numStarsFilled - 0.5);
   },
 
   _getStarOffset(rating, index) {
     const result = rating - index;
-    if (result > -0.01) {
-      return '100%';
-    } else if (result > -0.51) {
-      return '50%';
+    if (get(this, 'useHalfStars')) {
+      if (result > -0.01) {
+        return '100%';
+      } else if (result > -0.51) {
+        return '50%';
+      } else {
+        return '0%';
+      }
     } else {
-      return '0%';
+      if (result > -0.51) {
+        return '100%';
+      } else {
+        return '0%';
+      }
     }
   },
 


### PR DESCRIPTION
This adds the flag `useHalfStars`. By default it is set to `true`. If set to `false`, only whole stars will be used - half stars will be disabled.

https://github.com/vevix/ember-star-rating/issues/1