### PR TITLE
Use new modules syntax

### DIFF
--- a/addon/components/star-rating.js
+++ b/addon/components/star-rating.js
@@ -1,10 +1,8 @@
-import Component from 'ember-component';
-import computed from 'ember-computed';
-import get from 'ember-metal/get';
-import set from 'ember-metal/set';
-import { scheduleOnce } from 'ember-runloop';
+import Component from '@ember/component';
+import { computed, get, set } from '@ember/object';
+import { scheduleOnce } from '@ember/runloop';
 import { invokeAction } from 'ember-invoke-action';
-import { htmlSafe } from 'ember-string';
+import { htmlSafe } from '@ember/string';
 import layout from '../templates/components/star-rating';
 
 const RatingComponent = Component.extend({


### PR DESCRIPTION
Starting in Ember 2.16, deprecation warnings appear if the new modules syntax isn't used. Fixed the import statements to be as Ember expects from 2.16 onwards. https://www.emberjs.com/blog/2017/10/11/ember-2-16-released.html