### PR TITLE
Add the ability to specify whole numbers only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+
+/.idea

--- a/addon/components/star-rating.js
+++ b/addon/components/star-rating.js
@@ -2,9 +2,9 @@ import Component from 'ember-component';
 import computed from 'ember-computed';
 import get from 'ember-metal/get';
 import set from 'ember-metal/set';
-import { scheduleOnce } from 'ember-runloop';
-import { invokeAction } from 'ember-invoke-action';
-import { htmlSafe } from 'ember-string';
+import {scheduleOnce} from 'ember-runloop';
+import {invokeAction} from 'ember-invoke-action';
+import {htmlSafe} from 'ember-string';
 import layout from '../templates/components/star-rating';
 
 const RatingComponent = Component.extend({
@@ -15,6 +15,7 @@ const RatingComponent = Component.extend({
   numStars: 5,
   anyPercent: false,
   rating: 0,
+  wholeOnly: false,
   readOnly: false,
   width: 26,
   height: 26,
@@ -22,7 +23,7 @@ const RatingComponent = Component.extend({
   svgPath: 'M25.326,10.137c-0.117-0.361-0.431-0.625-0.807-0.68l-7.34-1.066l-3.283-6.651 c-0.337-0.683-1.456-0.683-1.793,0L8.82,8.391L1.48,9.457c-0.376,0.055-0.689,0.318-0.807,0.68c-0.117,0.363-0.02,0.76,0.253,1.025 l5.312,5.178l-1.254,7.31c-0.064,0.375,0.09,0.755,0.397,0.978c0.309,0.225,0.717,0.254,1.054,0.076L13,21.252l6.564,3.451 c0.146,0.077,0.307,0.115,0.466,0.115c0.207,0,0.413-0.064,0.588-0.191c0.308-0.223,0.462-0.603,0.397-0.978l-1.254-7.31 l5.312-5.178C25.346,10.896,25.443,10.5,25.326,10.137z',
   viewBox: '0 0 26 26',
 
-  style: computed('width', 'height', function() {
+  style: computed('width', 'height', function () {
     var style = '';
     if (get(this, 'width')) {
       style += `width: ${get(this, 'width')}; `;
@@ -36,7 +37,7 @@ const RatingComponent = Component.extend({
   init() {
     this._super(...arguments);
     const num = get(this, 'numStars');
-    const stars = Array.apply(null, { length: num }).map(() => 1);
+    const stars = Array.apply(null, {length: num}).map(() => 1);
     set(this, 'stars', stars);
   },
 
@@ -107,6 +108,11 @@ const RatingComponent = Component.extend({
     const pageX = event.pageX;
     const target = this._getTarget(pageX);
     const rating = Math.floor(target * 2) / 2;
+
+    if (get(this, 'wholeOnly') === true) {
+      return Math.ceil(rating);
+    }
+
     return rating;
   },
 
@@ -141,11 +147,17 @@ const RatingComponent = Component.extend({
   _updateStars(rating) {
     this.$().find('> svg').each((index, elem) => {
       let offset = 0;
+
       if (get(this, 'anyPercent') === true) {
         offset = (rating - index) > 0 ? ((rating - index) > 1 ? '100%' : `${((rating - index) * 100).toFixed(0)}%`) : '0%';
       } else {
         offset = this._getStarOffset(rating, index + 1);
       }
+
+      if (get(this, 'wholeOnly') === true) {
+        rating = Math.ceil(rating);
+      }
+
       this.$(elem).find('stop').eq(0).attr('offset', offset);
       let klass = offset === '100%' ? 'star-full' : (offset === '50%' ? 'star-half' : 'star-empty');
       if (get(this, 'anyPercent') === true && klass === 'star-empty' && offset !== '0%') {

--- a/index.js
+++ b/index.js
@@ -2,5 +2,9 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-star-rating'
+  name: 'ember-star-rating',
+
+  isDevelopingAddon() {
+    return true;
+  }
 };

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -3,6 +3,10 @@
   {{star-rating rating onClick=(action "setRating")}}
 </div>
 <div>
+  <h1>Whole Numbers</h1>
+  {{star-rating rating onClick=(action "setRating") wholeOnly=true}}
+</div>
+<div>
   <h1>Readonly</h1>
   {{star-rating 2.5 readOnly=true}}
 </div>


### PR DESCRIPTION
Right now we have the ability to accept half numbers or any percent, however, we're missing the core idea for whole numbers only in the current version. This addition should allow you to add the `wholeOnly` parameter to the component.