### PR TITLE
Fixes for better touch usage

### DIFF
--- a/addon/components/star-rating.js
+++ b/addon/components/star-rating.js
@@ -23,6 +23,7 @@ const RatingComponent = Component.extend({
 
   onHover: () => {},
   onClick: () => {},
+
   fastboot: computed(function () {
     let owner = getOwner(this);
     return owner.lookup('service:fastboot');
@@ -61,6 +62,7 @@ const RatingComponent = Component.extend({
   didInsertElement() {
     this._super(...arguments);
     this.$().css('display', 'inline-block');
+    this.$().css('user-select', 'none');
     if (get(this, 'readOnly') === false) {
       this.$().css('cursor', 'pointer');
     }
@@ -78,6 +80,21 @@ const RatingComponent = Component.extend({
 
   click(event) {
     const rating = this._update(event);
+    get(this, 'onClick')(rating || 0);
+  },
+
+  touchStart(event) {
+    this._render(event);
+  },
+
+  touchMove(event) {
+    this._render(event);
+  },
+
+  touchEnd(event) {
+    event.preventDefault();
+    const rating = this._update(event);
+    this._render(event);
     get(this, 'onClick')(rating || 0);
   },
 
@@ -123,7 +140,12 @@ const RatingComponent = Component.extend({
 
   _getTarget(x) {
     const numStars = get(this, 'numStars');
-    const numStarsFilled = (numStars * (x - this.$().offset().left) / this.$().width() + 0.5);
+    let numStarsFilled = (numStars * (x - this.$().offset().left) / this.$().width() + 0.5);
+
+    if (numStarsFilled > numStars) {
+      numStarsFilled = numStars;
+    }
+
     if (get(this, 'useHalfStars')) {
       return numStarsFilled;
     }


### PR DESCRIPTION
Now works on first tap, updates in real-time as touch is dragged across rating. 

See: https://github.com/trmcnvn/ember-star-rating/issues/17

**Problem:** 

First interaction with star rating takes two taps on mobile (safari, iOS) to get the onclick event to fire. 

**Reason:** 

http://sitr.us/2011/07/28/how-mobile-safari-emulates-mouse-events.html

https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Supporting_both_TouchEvent_and_MouseEvent

**Solution, described:** 

Touch events added. Mouse events will never be fired b/c of preventDefault() (see above link with event ordering). touchMove keeps it updating the UI if you drag your thumb across. touchEnd makes the changes after any dragging thumb stuff. 

I have also added a sanity check for numStarsFilled, so that dragging beyond the number of stars, during a touch event, will prevent the value exceeding the number of stars. In other words, without this, the touchEnd event could be fired (thumb lifted up) when the thumb is outside the component, and a five star rating component could return a rating of 8 (or other value higher than 5).

Also, user-select: none added to CSS. This prevents accidental highlighting during touch interactions. 

Boom. Enjoy.